### PR TITLE
Clinvar ingest expanded

### DIFF
--- a/src/clinvar_ingest/download.yaml
+++ b/src/clinvar_ingest/download.yaml
@@ -5,3 +5,9 @@
 ---
 - url: https://ftp.ncbi.nlm.nih.gov/pub/clinvar/vcf_GRCh38/clinvar.vcf.gz
   local_name: data/clinvar.vcf.gz
+
+- url: https://ftp.ncbi.nlm.nih.gov/pub/clinvar/tab_delimited/submission_summary.txt.gz
+  local_name: data/submission_summary.txt.gz
+
+- url: https://data.monarchinitiative.org/mappings/latest/mondo.sssom.tsv
+  local_name: data/mondo.sssom.tsv

--- a/src/clinvar_ingest/download.yaml
+++ b/src/clinvar_ingest/download.yaml
@@ -11,3 +11,6 @@
 
 - url: https://data.monarchinitiative.org/mappings/latest/mondo.sssom.tsv
   local_name: data/mondo.sssom.tsv
+
+- url: https://ftp.ncbi.nlm.nih.gov/pub/medgen/MedGenIDMappings.txt.gz
+  local_name: data/MedGenIDMappings.txt.gz

--- a/src/clinvar_ingest/download.yaml
+++ b/src/clinvar_ingest/download.yaml
@@ -14,3 +14,7 @@
 
 - url: https://ftp.ncbi.nlm.nih.gov/pub/medgen/MedGenIDMappings.txt.gz
   local_name: data/MedGenIDMappings.txt.gz
+
+## hgnc geneId conversion file (this is only used for development purposes)
+##- url: https://g-a8b222.dd271.03c0.data.globus.org/pub/databases/genenames/hgnc/tsv/hgnc_complete_set.txt
+##  local_name: data/hgnc_complete_set.txt

--- a/src/clinvar_ingest/transform.py
+++ b/src/clinvar_ingest/transform.py
@@ -38,8 +38,8 @@ def make_variant_record_map(submission_path):
                 var_records[varid].append(rec)
                 rec_count += 1
     
-    print("- {} variants read into memory across {} records".format(format(len(var_records), ','), 
-                                                                    format(rec_count, ',')))
+    ##print("- {} variants read into memory across {} records".format(format(len(var_records), ','), 
+    ##                                                                format(rec_count, ',')))
     return var_records
 
 
@@ -427,8 +427,6 @@ predicate_map = {"Pathogenic":CAUSES,
 
 # File paths to acessory data
 sub_path = "./data/submission_summary.txt.gz"
-vcf_tsv_path = "./data/clinvar.tsv"
-vcf_path = "./data/clinvar.vcf"
 sssom_path = "./data/mondo.sssom.tsv"
 medgen_path = "./data/MedGenIDMappings.txt.gz"
 
@@ -444,7 +442,7 @@ medgen_to_mondo = make_medgen_to_mondo_map(medgen_path)
 # Merge the two maps we made into one by updatating one dictionary with the other
 map_to_mondo.update(medgen_to_mondo)
 
-
+# Record keeping variables 
 no_record = 0
 with_record = 0
 map_stats = {"MONDO":0, "mesh":0, "OMIM":0, "Orphanet":0, "MedGen":0}

--- a/src/clinvar_ingest/transform.py
+++ b/src/clinvar_ingest/transform.py
@@ -1,7 +1,328 @@
 import uuid  # For generating UUIDs for associations
+import gzip
+import pandas as pd
+#import matplotlib.pyplot as plt
+from collections import Counter
 
 from biolink_model.datamodel.pydanticmodel_v2 import *  # Replace * with any necessary data classes from the Biolink Model
 from koza.cli_utils import get_koza_app
+
+
+### Create variant--> record mapping {variant_id:[record,...]}
+def make_variant_record_map(submission_filepath):
+    
+    # Last line with "#" character in it will be read as the header
+    var_records = {}
+    rec_count = 0
+    with gzip.open(submission_filepath, 'rt') as infile:
+        
+        for line in infile:
+            line = line.strip('\r').strip('\n')
+            if line[0] == "#":
+                header = line.split('\t')
+                
+                # Removes leading "#" character
+                header[0] = header[0][1:]
+                
+                # Links column name to column index
+                hcols = {k:i for i, k in enumerate(header)}
+            
+            else:
+                cols = line.split('\t')
+                varid = cols[hcols["VariationID"]]
+                if varid not in var_records:
+                    var_records.update({varid:[]})
+                
+                # Make our record and append
+                rec = {k:cols[hcols[k]] for k in hcols}
+                var_records[varid].append(rec)
+                rec_count += 1
+    
+    print("- {} variants read into memory across {} records".format(format(len(var_records), ','), 
+                                                                    format(rec_count, ',')))
+    return var_records
+
+
+### Create generalized disease_id to mondo_id map
+def make_mondo_map(sssom_path):
+    
+    # Last line with "#" character in it will be read as the header
+    var_records = {}
+    rec_count = 0
+    dups = 0
+    hcount = 0
+    map_to_mondo = {}
+    with open(sssom_path, 'r') as infile:
+
+        for line in infile:
+            line = line.strip('\r').strip('\n')
+
+            if not line:
+                continue
+
+            if line[0] == "#":
+                continue
+            else:
+                hcount += 1
+
+                # Make header to data
+                if hcount == 1:
+                    header = line.split('\t')
+
+                    # Links column name to column index
+                    hcols = {k:i for i, k in enumerate(header)}
+                    continue
+
+                cols = line.split('\t')
+                obj_id, subj_id = cols[hcols["object_id"]], cols[hcols["subject_id"]]
+
+                if obj_id not in map_to_mondo:
+                    map_to_mondo.update({obj_id:{}})
+                else:
+                    dups += 1
+                    #print(obj_id, map_to_mondo[obj_id])
+                    #print(obj_id, line)
+                    #print("###")
+
+                # A small amount of objects will map to more than one mondo id (hence the dict structure)
+                map_to_mondo[obj_id].update({subj_id:''})
+
+    print("- Total mappings produced {}".format(len(map_to_mondo)))
+    print("- Multi mapping objects found {}".format(format(dups, ',')))
+    
+    # Lastly, add in bannana and mondo_id mapping to self
+    mondo_set = {k.split(":")[-1]:'' for kv in map_to_mondo for k in map_to_mondo[kv]}
+    for k in mondo_set:
+        v = "MONDO:{}".format(k)
+        kv = "MONDO:MONDO:{}".format(k)
+        
+        map_to_mondo.update({v:{v:''}})
+        map_to_mondo.update({kv:{v:''}})
+    
+    return map_to_mondo
+    
+
+def make_genes_from_row(gene_list):
+    if gene_list == '.':
+        return [], []
+    gene_ids, gene_symbols = [], []
+    genes = gene_list.split('|')
+    for gene in genes:
+        values = gene.split(':')[1:]  # sometimes there's more than one Entrez ID after the symbol
+        gene_sym = gene.split(':')[0]
+        for value in values:
+            gene_ids.append("NCBIGene:{}".format(value))
+            gene_symbols.append(gene_sym)
+    return gene_ids, gene_symbols
+
+
+def format_id_to_map(info):
+    
+    idnum = info.split(':')[-1]     
+    if "MONDO:" in info:
+        idname = "MONDO:{}".format(idnum)
+
+    elif "HP" in info:
+        idname = "HP:{}".format(idnum)
+
+    elif "MeSH" in info:
+        idname = "mesh:{}".format(idnum)
+        
+    elif "." == info:
+        idname = None
+        
+    else:
+        idname = info
+    
+    return idname
+  
+
+def get_variant_to_disease_predicate(term, pathogenicity_lookup):
+    
+    if term in pathogenic_lookup:
+        predicate = "biolink:causes"
+    else:
+        predicate = "biolink:contributes_to"
+    
+    return predicate    
+
+
+def variant_records_to_disease(record_list, review_star_map, map_to_mondo, pathogenicity_lookup, star_min=3):
+    
+    # Each record is a dictionary. We have a list of records that we can loop through
+    # keys = 
+    # VariationID, ClinicalSignificance, DateLastEvaluated, 
+    # Description, SubmittedPhenotypeInfo, ReportedPhenotypeInfo, 
+    # ReviewStatus, CollectionMethod, OriginCounts, Submitter, SCV
+    dis = {}
+    preds = {}
+    org_preds = {}
+    for rec in record_list:
+        stars = int(review_star_map[rec["ReviewStatus"].replace(" ", "_")])
+        if stars < star_min:
+            continue
+        
+        clinsig = rec["ClinicalSignificance"]
+        mapped_predicate = get_variant_to_disease_predicate(clinsig, pathogenicity_lookup)
+        org_predicate = clinsig
+        
+        for dis_id in rec["SubmittedPhenotypeInfo"].split(';'):
+            
+            # Convert to MONDO_ID if we can
+            dis_id = format_id_to_map(dis_id)
+            mondo_ids = []
+            if dis_id in map_to_mondo:
+                mondo_ids = list(map_to_mondo[dis_id].keys())
+            
+            elif "MONDO:" in dis_id:
+                mondo_ids = [dis_id]
+            
+            # Can't map this one back
+            if len(mondo_ids) == 0:
+                continue
+            
+            for d in mondo_ids:
+                dis.update({d:''})
+                if d not in preds:
+                    preds.update({d:{}})
+                    org_preds.update({d:{}})
+                preds[d].update({mapped_predicate:''})
+                org_preds[d].update({org_predicate:''})
+                
+    return dis, preds, org_preds
+   
+
+def parse_CLNDISDB(column):
+    
+    # Output datastructure [{"MAP_TERMS":[], "HP":[]}, {...]
+    diss = []
+
+    # Loop through each disease the variant is associated with
+    for group_info in column.split('|'):
+
+        # Each one can have multiple ids associated with it
+        default = {"MAP_TERMS":[],
+                   "HP":[]}
+        
+        # Can have multiple hp terms associated with a single disease (can tune formatting for each term)
+        for info in group_info.split(','):
+            
+            idname = format_id_to_map(info)
+            if idname == None:
+                continue
+            
+            # Separate by hp terms and disease ids (that should be mapped back to mondo)
+            if "HP:" in idname:
+                default["HP"].append(idname)
+            else:
+                default["MAP_TERMS"].append(idname)
+                
+        # Add our parsed information to return datastructure
+        diss.append(default)
+    
+    # Filter for things that have at least 1 or more hp or disease terms
+    diss = [d for d in diss if len(d["HP"]) > 0 or len(d["MAP_TERMS"]) > 0]
+    
+    return diss
+
+
+def map_CLNDISDB_to_mondo(parse_results, map_to_mondo, map_stats={"MONDO":0, "mesh":0, "OMIM":0, "Orphanet":0}):
+    
+    for i, d in enumerate(parse_results):
+        
+        map_terms = d["MAP_TERMS"]
+        mondo_ids = []
+        for gterm in map_terms:
+
+            if "MONDO:" in gterm:
+                mondo_ids.append(gterm)
+                map_stats["MONDO"] += 1
+                
+            elif gterm in map_to_mondo:
+                mondo_ids += list(map_to_mondo[gterm].keys())
+                
+                ### STATS KEEPING
+                for k in map_stats:
+                    if k in gterm:
+                        map_stats[k] += 1
+            
+            else:
+                unknown = "unkown_source_{}".format(''.join(gterm.split(":")[:-1]))
+                if unknown not in map_stats:
+                    map_stats.update({unknown:0})
+                map_stats[unknown] += 1
+        
+        parse_results[i]["MAP_TERMS"] = mondo_ids
+    
+    return parse_results, map_stats
+
+
+def map_mondo_to_hp(group_info, disease_ids):
+    mondo_to_hp = {}
+    for g in group_info:
+        
+        # Loop through each disease_id term and see if it matches any disease this variant is associated with
+        for d in g["MAP_TERMS"]:
+            if d in disease_ids:
+                
+                # Check if exists or not currently. We can pull in multiple hp terms from records that
+                # have the same disease id as the "cononical" disease for this set of records
+                if d not in mondo_to_hp:
+                    mondo_to_hp.update({d:[]})
+                    
+                mondo_to_hp[d] += g["HP"]
+
+    return mondo_to_hp
+
+
+def map_records_to_disease_hp(record_list, 
+                              clndisdb_column, 
+                              review_star_map, 
+                              map_to_mondo, 
+                              pathogenicity_lookup, 
+                              star_min=3):
+    
+    # Disease --> HP modeling pipeline
+    
+    # Variant records --> MONDO:ID based on review status of ACMG. Ratings < star_min will not have an association
+    disease_ids, disease_predicates, org_predicates  = variant_records_to_disease(record_list, 
+                                                                                   review_star_map, 
+                                                                                   map_to_mondo, 
+                                                                                   pathogenicity_lookup,
+                                                                                   star_min)
+    
+    # Pull and format disease_ids and HP terms
+    diss_info = parse_CLNDISDB(clndisdb_column)
+    
+    # Map inormation to mondo id if possible and discard otherwise
+    diss_info = map_CLNDISDB_to_mondo(diss_info, map_to_mondo)
+    
+    # Map each disease to HP terms if possible
+    mondo_to_hp = map_mondo_to_hp(diss_info, disease_ids)
+
+    return mondo_to_hp, disease_predicates, org_predicates
+    
+
+########################################################################################
+### Pipeline is to first create a variant to record(s) map {variantid:[{},{},{}...]} ###
+
+### Then second is to create a disease id to mondo id map in the form of...
+### map_to_mondo --> {"OMIM:123":"MONDO:123", ...}.
+### where the key (disease id) is from the sources found within the sssom file
+
+### The map_to_mondo is able to handle a few different types of data
+### Orphanet, OMIM, Mondo, and some MeSH for this data set 
+
+### Then we attempt to map all disease ids found within any gene back to this map (map_to_mondo).
+### If MONDO is found within the id name and it isn't found in the map, then it is included anyways.
+### This results in only making variantToDisease associations if the disease id is found in our map / is a mondo id.
+### We are currently lacking MedGen which seems to be a large portion of the variant annotaitions within the vcf, but
+### doesn't necessarily mean they all contribute to connections we want to make
+
+### Map disease id --> mondo id
+### Review status term of record --> stars determines if variantToDiesease association is made, AND HP associations (if possible)
+### Can use 0,1,2,3,4 star mapping min to get different results (see review_star_map below)
+
 
 koza_app = get_koza_app("clinvar_variant")
 
@@ -10,77 +331,135 @@ CAUSES = "biolink:causes"
 HAS_PHENOTYPE = "biolink:has_phenotype"
 IS_SEQUENCE_VARIANT_OF = 'biolink:is_sequence_variant_of'
 
-# def parse_vcf_info_column(info_column):
-#     rel_columns = {"GENEINFO":'',      # Gene(s) for the variant reported as gene symbol:gene id. The gene symbol and id are delimited by a colon (:) and each pair is delimited by a vertical bar (|)
-#                    "ORIGIN":'',       # Allele origin. One or more of the following values may be added: 0 - unknown; 1 - germline; 2 - somatic; 4 - inherited; 8 - paternal; 16 - maternal; 32 - de-novo; 64 - biparental; 128 - uniparental; 256 - not-tested; 512 - tested-inconclusive; 1073741824 - other">
+# Manually curated terms derived from files for data modeling purposes
+review_star_map = {"practice_guideline":4,
+                   "reviewed_by_expert_panel":3,
+                   "criteria_provided,_multiple_submitters,_no_conflicts":2,
+                   "criteria_provided,_conflicting_classifications":2,
+                   "no_classifications_from_unflagged_records":1,
+                   "criteria_provided,_single_submitter":1,
+                   "no_assertion_criteria_provided":1,
+                   "no_classification_provided":1,
+                   "no_classification_for_the_single_variant":0,
+                   "flagged_submission":0, # ??? Conflicting information is what the really means...
+                   ".":0} #Means that there is no data submitted for germline classification"
 
-#                    "CLNDISDB":'',     # Tag-value pairs of disease database name and identifier submitted for germline classifications
-#                    "CLNREVSTAT":'',   # ClinVar review status of germline classification for the Variation ID
+var2disease_star_min = 3
 
-#                    "ONCDISDB":'',     # Tag-value pairs of disease database name and identifier submitted for oncogenicity classifications, e.g. MedGen:NNNNNN">
-#                    "ONCREVSTAT":'',   # ClinVar review status of oncogenicity classification for the Variation ID">"
+# Manually curated to help determine predicate
+pathogenic_enums = ["Likely pathogenic", 
+                    "Likely pathogenic, low penetrance", 
+                    "Pathogenic", "Pathogenic, low penetrance",
+                    "Pathogenic/Likely pathogenic"]
 
-#                    "SCIDISDB":'',     # Tag-value pairs of disease database name and identifier submitted for somatic clinial impact classifications, e.g. MedGen:NNNNNN
-#                    "SCIREVSTAT":'',   # ClinVar review status of somatic clinical impact for the Variation ID
-#                    "CLNHGVS":'',      # Variant info / name
+pathogenic_lookup = {k:'' for k in pathogenic_enums}
 
-# Only ontology terms we are interested in are HPO and MONDO
-#'AF_ESP=0.00008;AF_EXAC=0.00002;ALLELEID=980658;CLNDISDB=MedGen:C3661900|Human_Phenotype_Ontology:HP:0000730,Human_Phenotype_Ontology:HP:0001249,Human_Phenotype_Ontology:HP:0001267,Human_Phenotype_Ontology:HP:0001286,Human_Phenotype_Ontology:HP:0002122,Human_Phenotype_Ontology:HP:0002192,Human_Phenotype_Ontology:HP:0002316,Human_Phenotype_Ontology:HP:0002382,Human_Phenotype_Ontology:HP:0002386,Human_Phenotype_Ontology:HP:0002402,Human_Phenotype_Ontology:HP:0002458,Human_Phenotype_Ontology:HP:0002482,Human_Phenotype_Ontology:HP:0002499,Human_Phenotype_Ontology:HP:0002543,Human_Phenotype_Ontology:HP:0003767,Human_Phenotype_Ontology:HP:0006833,Human_Phenotype_Ontology:HP:0007154,Human_Phenotype_Ontology:HP:0007176,Human_Phenotype_Ontology:HP:0007180,MONDO:MONDO:0001071,MeSH:D008607,MedGen:C3714756|Human_Phenotype_Ontology:HP:0001380,Human_Phenotype_Ontology:HP:0001383,Human_Phenotype_Ontology:HP:0001388,Human_Phenotype_Ontology:HP:0002771,MedGen:C0086437;CLNDN=not_provided|Intellectual_disability|Joint_laxity;CLNHGVS=NC_000001.11:g.2304067C>T;CLNREVSTAT=criteria_provided,_multiple_submitters,_no_conflicts;CLNSIG=Uncertain_significance;CLNVC=single_nucleotide_variant;CLNVCSO=SO:0001483;GENEINFO=SKI:6497;MC=SO:0001583|missense_variant;ORIGIN=1;RS=367916348'}
+# File paths to acessory data
+sub_path = "./data/submission_summary.txt.gz"
+vcf_tsv_path = "./data/clinvar.tsv"
+vcf_path = "./data/clinvar.vcf"
+sssom_path = "./data/mondo.sssom.tsv"
 
+# Map records to each clinvar variant id
+var_records = make_variant_record_map(sub_path)
+print("- Var records read in {}".format(format(len(var_records), ',')))
 
-# TO DO (how to link to existing gene_ids already in database)
-def make_genes_from_row(gene_list):
-    if gene_list == '.':
-        return []
-    gene_ids = []
-    genes = gene_list.split('|')
-    for gene in genes:
-        values = gene.split(':')[1:]  # sometimes there's more than one Entrez ID after the symbol
-        for value in values:
-            gene_ids.append("NCBIGene:{}".format(value))
-    return gene_ids
+# Make general map back to mondo terms for things that are in our vcf / submission_summary files
+map_to_mondo = make_mondo_map(sssom_path)
+print("- mondo sssom read in {}".format(format(len(map_to_mondo), ',')))
 
-    # ZNRF2:223082|LOC105375218:105375218|LOC129998188:12999818
+# Koza app loop through each line of the file as a dictionary 
+no_record = 0
+with_record = 0
+var_to_diss = 0
+dis_hp_counts = {i:0 for i in range(0, 50)}
+map_stats = {"MONDO":0, "mesh":0, "OMIM":0, "Orphanet":0}
 
+vars_added = 0
+var2gene_added = 0
+var2dis_added = 0
+var2hp_added = 0
 
-def extract_ids(prefix, value):
-    ids = []
-    groups = value.split('|')
-    for group in groups:
-        items = group.split(',')
-        for item in items:
-            # replace the MONDO banana if necessary
-            item.replace('MONDO:MONDO:', 'MONDO:')
-            # deal with HP DB name + prefix
-            item.replace('Human_Phenotype_Ontology:HP:', 'HP:')
-            if item.startswith(prefix):
-                ids.append(item)
-    return ids
-
-
+tot_count = 0
 while (row := koza_app.get_row()) is not None:
     # Code to transform each row of data
     # For more information, see https://koza.monarchinitiative.org/Ingests/transform
 
+    tot_count += 1
+    if tot_count % 100000 == 0:
+        print("- Processed {}".format(format(tot_count, ',')))
+
+    # Graph level objects we need koza to write
     entities = []
 
-    gene_ids = make_genes_from_row(row["GENEINFO"])
-
+    # Values we need pull
+    varid = str(row["ID"])
     clinical_significance = row["CLNSIG"]
+    crev = row["CLNREVSTAT"]
+    ginfo = row["GENEINFO"]
+    raw_diss_info = row["CLNDISDB"]
+    
+    # Initial acmg filtering here
+    # This is also performed from variant_records_to_disease function so it is left out
+    ###stars = review_star_map[crev]
+    ###if stars < var2disease_star_min:
+    ###    continue
+    
+    if varid not in var_records:
+        no_record += 1
+        continue
+    else:
+        with_record += 1
+    
+    # Make SequenceVariant (must first find genes that are associated with it to pass in)
+    gene_ids, gene_symbols = make_genes_from_row(ginfo)
 
+#     # This should do four steps in one fell swoop
+#     # Disease --> Disease + HP pipeline
+#     # Finds uniq mondo_ids, and linked hp terms (if possible)
+#     # Filters for records < star_min (ACMG review status "exper panel and practice guidlines")
+#     mondo_to_hp, d_preds, org_preds = map_records_to_disease_hp(record_list=var_records[varid],
+#                                                                 clndisdb_column=raw_diss_info, 
+#                                                                 review_star_map=review_star_map, 
+#                                                                 map_to_mondo=map_to_mondo,
+#                                                                 pathogenicity_lookup=pathogenic_lookup,
+#                                                                 star_min=3)
+    
+    # Variant records --> MONDO:ID based on review status of ACMG. Ratings < star_min will not have an association
+    disease_ids, disease_predicates, org_predicates  = variant_records_to_disease(var_records[varid], 
+                                                                                  review_star_map, 
+                                                                                  map_to_mondo, 
+                                                                                  pathogenic_lookup,
+                                                                                  star_min=var2disease_star_min)
+    
+    # Pull and format disease_ids and HP terms
+    diss_info = parse_CLNDISDB(raw_diss_info)
+    
+    # Map inormation to mondo id if possible and discard otherwise
+    diss_info, map_stats = map_CLNDISDB_to_mondo(diss_info, map_to_mondo, map_stats)
+    
+    # Map each disease to HP terms if possible
+    # {MONDO:123:[HP:123, HP:234, ...], ...}
+    mondo_to_hp = map_mondo_to_hp(diss_info, disease_ids) #--> {disease_id:[HP:123, HP:234, ...], }
+
+    # TO DO: Fill out more?
+    # Start creating graph data starting with the variant itself
     seq_var = SequenceVariant(
         id="CLINVAR:{}".format(row["ID"]),
         name=row["CLNHGVS"],
         xref=["DBSNP:{}".format(row["RS"])],
         has_gene=gene_ids,
         in_taxon=["NCBITaxon:9606"],
-        in_taxon_label="Homo sapiens",
+        in_taxon_label="Homo sapiens")
         # type? could this be a SO term?
         # has_bioligical_sequence  do we want it? not so sure
-    )
+# #     )
 
     entities.append(seq_var)
-
+    vars_added += 1
+    
+    # TO DO: Fill out more? MC (molecular consequence value(s)) How to ascribe multiple terms with the gene info...
+    # Make Gene Associations
     for gene_id in gene_ids:
         entities.append(
             VariantToGeneAssociation(
@@ -94,49 +473,92 @@ while (row := koza_app.get_row()) is not None:
                 agent_type=AgentTypeEnum.manual_agent,  # TODO: we should confirm this
             )
         )
+        var2gene_added += 1
+    
 
-    mondo_ids = extract_ids('MONDO', row['CLNDISDB'])
-    if len(mondo_ids) == 0:
-        continue  # exit without writing the sequence variant entity if there's no disease association
-
-    for mondo_id in mondo_ids:
-        if clinical_significance == 'Benign' or clinical_significance == 'Likely_benign':
-            predicate = CONTRIBUTES_TO
-            negated = True
-        elif clinical_significance == 'Likely_pathogenic' or clinical_significance == 'Pathogenic':
-            predicate = CAUSES
-            negated = False
-        else:
-            # uncertain significance or mixed / complicated, skip for now
-            continue
-
-        entities.append(
-            VariantToDiseaseAssociation(
-                id=str(uuid.uuid4()),
-                subject=seq_var.id,
-                predicate=predicate,
-                qualifiers=[row["CLNREVSTAT"]],
-                object=mondo_id,
-                original_predicate=row["CLNSIG"],
-                primary_knowledge_source="infores:clinvar",
-                aggregator_knowledge_source=["infores:monarchinitiative"],
-                knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
-                agent_type=AgentTypeEnum.manual_agent,
+    # TO DO: Predicate when and what still needs work 
+    # Create VariantToDiseaseAssociations 
+    for dis_id, predicate in disease_predicates.items():
+        
+        # We can curate predicate from anywhere here (original record file, or what the vcf provides)
+        # Can be able to process multiple predicates (or we can remove this)
+        #for og_pred in o/g_preds:
+        #    if og_pred in pathogenic_lookup:
+        #        predicate = CAUSES
+        #        negated = False
+        #    else:
+        #        predicate = CONTRIBUTES_TO
+        #        negated = True
+        
+        ### predicate is a dictionary of possible predicate values (in case a variant has multiple status's? (not sure possible...))
+        for pred in list(predicate.keys()):
+            entities.append(
+                VariantToDiseaseAssociation(
+                    id=str(uuid.uuid4()),
+                    subject=seq_var.id,
+                    predicate=pred,
+                    qualifiers=[row["CLNREVSTAT"]],
+                    object=dis_id,
+                    original_predicate=row["CLNSIG"], # This can also be pulled from submission_summary records...,
+                    primary_knowledge_source="infores:clinvar",
+                    aggregator_knowledge_source=["infores:monarchinitiative"],
+                    knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+                    agent_type=AgentTypeEnum.manual_agent,
+                )
             )
-        )
+            var2dis_added += 1
+    
 
-    for hp_id in extract_ids('Human_Phenotype_Ontology:HP:', row['CLNDISDB']):
-        entities.append(
-            VariantToPhenotypicFeatureAssociation(
-                id=str(uuid.uuid4()),
-                subject=seq_var.id,
-                predicate=CONTRIBUTES_TO,
-                object=hp_id,
-                primary_knowledge_source="infores:clinvar",
-                aggregator_knowledge_source=["infores:monarchinitiative"],
-                knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
-                agent_type=AgentTypeEnum.manual_agent,
+    # TO DO: Predicate when and what still needs work
+    # Create Variant to HP assocations (Currently dependent on an existing VariantToDisease association)
+    for mondo_id, hp_terms in mondo_to_hp.items():
+        for hp_id in hp_terms:
+            entities.append(
+                VariantToPhenotypicFeatureAssociation(
+                    id=str(uuid.uuid4()),
+                    subject=seq_var.id,
+                    predicate=CONTRIBUTES_TO,
+                    object=hp_id,
+                    primary_knowledge_source="infores:clinvar",
+                    aggregator_knowledge_source=["infores:monarchinitiative"],
+                    knowledge_level=KnowledgeLevelEnum.knowledge_assertion,
+                    agent_type=AgentTypeEnum.manual_agent,
+                )
             )
-        )
+            var2hp_added += 1
+    
+    # Stats here
+    #dis_counts[len(hp_terms)] += 1
+    
+    # Test case with 11 hp terms
+    # for dis, hp_terms in mondo_to_hp.items():
+    #     if len(hp_terms) == 11:
+    #         print(dis, hp_terms)
+    #         for rr in var_records[varid]:
+    #             print(rr)
+    
+    # Record keeping
+    if len(mondo_to_hp) > 0:
+        var_to_diss += len(mondo_to_hp)
+    
+    for m_id, hps in mondo_to_hp.items():
+        dis_hp_counts[len(hps)] += 1
+    
 
     koza_app.write(*entities)
+
+
+# This won't actually will be printed, but would be nice to keep track of in a stats file or something   
+print("- No records {}".format(no_record))
+print("- With records {}".format(with_record))
+print("- VariantsToDisease {}".format(format(var_to_diss, ',')))
+print("")
+print("-Variants added {}".format(format(vars_added, ',')))
+print("-Variant to gene edges {}".format(format(var2gene_added, ',')))
+print("-Variant to disease edges {}".format(format(var2dis_added, ',')))
+print("-Variant to hp edges {}".format(format(var2hp_added, ',')))
+for k, v in map_stats.items():
+    print("- {} --> mondo_id , {}".format(k, format(v, ',')))
+    
+for k, v in dis_hp_counts.items():
+    print("- HP Associations {}, Number of cases {}".format(k, v))

--- a/src/clinvar_ingest/transform.yaml
+++ b/src/clinvar_ingest/transform.yaml
@@ -4,8 +4,12 @@
 name: "clinvar_variant"
 metadata: "./src/clinvar_ingest/metadata.yaml"
 format: "csv" # Format of the data files (csv or json)
+delimiter: "\t"
+
 files:
   - "./data/clinvar.tsv"
+
+
 #################################################################################################
 ### file_archive is typically optional, but required if:                                      ###
 ###    1. files is not provided                                                               ###
@@ -125,3 +129,12 @@ header: 0
 # header_prefix: Prefix for header in csv files
 # comment_char: Comment character for csv files
 # skip_blank_lines: Boolean - whether to skip blank lines in csv files
+
+
+# sssom_config:
+#   files:
+#      - 'data/mondo.sssom.tsv'
+#   object_target_prefixes:
+#      - 'MONDO'
+#   use_match: 
+#      - 'skos:exactMatch' 

--- a/src/clinvar_ingest/transform.yaml
+++ b/src/clinvar_ingest/transform.yaml
@@ -9,6 +9,11 @@ delimiter: "\t"
 files:
   - "./data/clinvar.tsv"
 
+## For hgnc gene id pre conversion (for development purposes only)
+##depends_on:
+##  - "./src/clinvar_ingest/hgnc_from_symbol.yaml"
+##  - "./src/clinvar_ingest/hgnc_from_name.yaml"
+
 
 #################################################################################################
 ### file_archive is typically optional, but required if:                                      ###

--- a/tests/test_clinvar.py
+++ b/tests/test_clinvar.py
@@ -79,22 +79,22 @@ def test_case1_row():
 def test_case2_row():
     row = {
         'CHROM':'1',
-        'POS':'964512',
-        'ID':'916564',
-        'REF':'C',
+        'POS':'171636092',
+        'ID':'2505295',
+        'REF':'T',
         'ALT':'A',
         'QUAL':'.',
         'FILTER':'.',
         'AF_ESP':'.',
         'AF_EXAC':'.',
         'AF_TGP':'.',
-        'ALLELEID':'904889',
-        'CLNDN':'Tracheoesophageal_fistula',
+        'ALLELEID':'2670262',
+        'CLNDN':'Glaucoma_of_childhood',
         'CLNDNINCL':'.',
-        'CLNDISDB':'Human_Phenotype_Ontology:HP:0002575,MONDO:MONDO:0008586,MeSH:D014138,MedGen:C0040588,OMIM:189960,Orphanet:1199',
+        'CLNDISDB':'Human_Phenotype_Ontology:HP:0001087,MONDO:MONDO:0020367,MedGen:C2981140,Orphanet:98977',
         'CLNDISDBINCL':'.',
-        'CLNHGVS':'NC_000001.11:g.964512C>A',
-        'CLNREVSTAT':'no_assertion_criteria_provided',
+        'CLNHGVS':'NC_000001.11:g.171636092T>A',
+        'CLNREVSTAT':'reviewed_by_expert_panel',
         'CLNSIG':'Likely_pathogenic',
         'CLNSIGCONF':'.',
         'CLNSIGINCL':'.',
@@ -102,7 +102,7 @@ def test_case2_row():
         'CLNVCSO':'SO:0001483',
         'CLNVI':'.',
         'DBVARID':'.',
-        'GENEINFO':'KLHL17:339451',
+        'GENEINFO':'MYOC:4653',
         'MC':'SO:0001583|missense_variant',
         'ONCDN':'.',
         'ONCDNINCL':'.',
@@ -112,8 +112,8 @@ def test_case2_row():
         'ONCINCL':'.',
         'ONCREVSTAT':'.',
         'ONCCONF':'.',
-        'ORIGIN':'32',
-        'RS':'756054473',
+        'ORIGIN':'1',
+        'RS':'.',
         'SCIDN':'.',
         'SCIDNINCL':'.',
         'SCIDISDB':'.',
@@ -124,35 +124,35 @@ def test_case2_row():
             }
     return row
 
-# Single record, Single mondoID, 3 HPO terms, Single gene
+# Two records, Two mondoIDs, 2 HPO terms, Single gene
 @pytest.fixture
 def test_case3_row():
     row = {
-        'CHROM':'1',
-        'POS':'1233041',
-        'ID':'666963',
+        'CHROM':'2',
+        'POS':'202464950',
+        'ID':'8797',
         'REF':'C',
-        'ALT':'T',
+        'ALT':'G',
         'QUAL':'.',
         'FILTER':'.',
         'AF_ESP':'.',
         'AF_EXAC':'.',
         'AF_TGP':'.',
-        'ALLELEID':'654170',
-        'CLNDN':'Spondyloepiphyseal_dysplasia',
+        'ALLELEID':'23836',
+        'CLNDN':'Pulmonary_arterial_hypertension|Pulmonary_hypertension,_primary,_1',
         'CLNDNINCL':'.',
-        'CLNDISDB':'Human_Phenotype_Ontology:HP:0002655,Human_Phenotype_Ontology:HP:0002776,Human_Phenotype_Ontology:HP:0005893,MONDO:MONDO:0016761,MedGen:C0038015,Orphanet:253',
+        'CLNDISDB':'Human_Phenotype_Ontology:HP:0002092,Human_Phenotype_Ontology:HP:0006546,MONDO:MONDO:0015924,MeSH:D000081029,MedGen:C2973725,Orphanet:182090|MONDO:MONDO:0024533,MedGen:C4552070,OMIM:178600,Orphanet:422',
         'CLNDISDBINCL':'.',
-        'CLNHGVS':'NC_000001.11:g.1233041C>T',
-        'CLNREVSTAT':'criteria_provided,_single_submitter',
-        'CLNSIG':'Likely_pathogenic',
+        'CLNHGVS':'NC_000002.12:g.202464950C>G',
+        'CLNREVSTAT':'reviewed_by_expert_panel',
+        'CLNSIG':'Pathogenic',
         'CLNSIGCONF':'.',
         'CLNSIGINCL':'.',
         'CLNVC':'single_nucleotide_variant',
         'CLNVCSO':'SO:0001483',
-        'CLNVI':'.',
+        'CLNVI':'ClinGen:CA278072|OMIM:600799.0003',
         'DBVARID':'.',
-        'GENEINFO':'B3GALT6:126792',
+        'GENEINFO':'BMPR2:659',
         'MC':'SO:0001587|nonsense',
         'ONCDN':'.',
         'ONCDNINCL':'.',
@@ -163,7 +163,7 @@ def test_case3_row():
         'ONCREVSTAT':'.',
         'ONCCONF':'.',
         'ORIGIN':'1',
-        'RS':'1239366051',
+        'RS':'137852742',
         'SCIDN':'.',
         'SCIDNINCL':'.',
         'SCIDISDB':'.',
@@ -373,27 +373,28 @@ def test_case6_entities(test_case6_row, mock_koza):
 ### Our actual tests ###
 
 def test_case1(test_case1_entities):
-    assert len(test_case1_entities) == 3 # SequenceVariant, VariantToDisease, VariantToGene
+    assert len(test_case1_entities) == 3 # SequenceVariant, VariantToGene. VariantToDisease
 
 def test_case2(test_case2_entities):
-    assert len(test_case2_entities) == 4 # SequenceVariant, VariantToDisease, VariantToGene, VariantToPhenotype
+    assert len(test_case2_entities) == 4 # SequenceVariant, VariantToGene, VariantToDisease, VariantToPhenotype
 
 def test_case3(test_case3_entities):
-    assert len(test_case3_entities) == 6 # SequenceVariant, VariantToDisease, VariantToGene, VariantToPhenotype, VariantToPhenotype, VariantToPhenotype
+    assert len(test_case3_entities) == 5 # SequenceVariant,  VariantToGene, VariantToDisease, VariantToPhenotype, VariantToPhenotype
     assert len([association for association in test_case3_entities if isinstance(association, VariantToPhenotypicFeatureAssociation)]) == 2
+    assert test_case3_entities[2].object == "MONDO:0015924" # Two potential mondo ids are listed in the records
 
 def test_case4(test_case4_entities):
-    assert len(test_case4_entities) == 3 # SequenceVariant, VariantToDisease, VariantToGene
+    assert len(test_case4_entities) == 3 # SequenceVariant, VariantToGene, VariantToDisease
     assert test_case4_entities[2].object == "MONDO:0100283" # Multiple mondoids are available and this is the one that should be chosen
 
 def test_case5(test_case5_entities):
-    assert len(test_case5_entities) == 5 # SequenceVariant, VariantToDisease, VariantToGene, VariantToPhenotype1, VariantToPhenotype2
+    assert len(test_case5_entities) == 5 # SequenceVariant, VariantToGene, VariantToDisease, VariantToPhenotype1, VariantToPhenotype2
     assert test_case5_entities[2].object == "MONDO:0015924" # Multiple mondoids are available and this is the one that should be chosen
     assert len([association for association in test_case5_entities if isinstance(association, VariantToPhenotypicFeatureAssociation)]) == 2
 
 def test_case6(test_case6_entities):
-    assert len(test_case6_entities) == 9 # SequenceVariant, VariantToDisease, VariantToGene1, VariantToGene2, VariantToPhenotype_x_5 
-    assert test_case6_entities[2].object == "MONDO:0019118" # Multiple mondoids are available and this is the one that should be chosen
+    assert len(test_case6_entities) == 9 # SequenceVariant, VariantToGene1, VariantToGene2, VariantToDisease, VariantToPhenotype_x_5 
+    assert test_case6_entities[3].object == "MONDO:0019118" # Multiple mondoids are available and this is the one that should be chosen
     assert len([association for association in test_case6_entities if isinstance(association, VariantToGeneAssociation)]) == 2
     assert len([association for association in test_case6_entities if isinstance(association, VariantToPhenotypicFeatureAssociation)]) == 5
 

--- a/tests/test_clinvar.py
+++ b/tests/test_clinvar.py
@@ -21,147 +21,382 @@ INGEST_NAME = "clinvar_variant"
 TRANSFORM_SCRIPT = "./src/clinvar_ingest/transform.py"
 
 
-# Define an example row to test (as a dictionary)
-@pytest.fixture
-def no_mondo_row():
+#################################################################
+### Rows taken from vcf file that have our desired test cases ###
 
-    # First line in the current clinvar vcf
+# Single record, Single mondoID, No HPO, Single Gene
+@pytest.fixture
+def test_case1_row():
     row = {
-        'CHROM': '1',
-        'POS': '69134',
-        'ID': '2205837',
-        'REF': 'A',
-        'ALT': 'G',
-        'QUAL': '.',
-        'FILTER': '.',
-        'AF_ESP': '.',
-        'AF_EXAC': '.',
-        'AF_TGP': '.',
-        'ALLELEID': '2193183',
-        'CLNDN': 'not_specified',
-        'CLNDNINCL': '.',
-        'CLNDISDB': 'MedGen:CN169374',
-        'CLNDISDBINCL': '.',
-        'CLNHGVS': 'NC_000001.11:g.69134A>G',
-        'CLNREVSTAT': 'criteria_provided,_single_submitter',
-        'CLNSIG': 'Likely_benign',
-        'CLNSIGCONF': '.',
-        'CLNSIGINCL': '.',
-        'CLNVC': 'single_nucleotide_variant',
-        'CLNVCSO': 'SO:0001483',
-        'CLNVI': '.',
-        'DBVARID': '.',
-        'GENEINFO': 'OR4F5:79501',
-        'MC': 'SO:0001583|missense_variant',
-        'ONCDN': '.',
-        'ONCDNINCL': '.',
-        'ONCDISDB': '.',
-        'ONCDISDBINCL': '.',
-        'ONC': '.',
-        'ONCINCL': '.',
-        'ONCREVSTAT': '.',
-        'ONCCONF': '.',
-        'ORIGIN': '1',
-        'RS': '.',
-        'SCIDN': '.',
-        'SCIDNINCL': '.',
-        'SCIDISDB': '.',
-        'SCIDISDBINCL': '.',
-        'SCIREVSTAT': '.',
-        'SCI': '.',
-        'SCIINCL': '.',
+        'CHROM':'1',
+        'POS':'11128107',
+        'ID':'1296989',
+        'REF':'G',
+        'ALT':'C',
+        'QUAL':'.',
+        'FILTER':'.',
+        'AF_ESP':'.',
+        'AF_EXAC':'.',
+        'AF_TGP':'.',
+        'ALLELEID':'1286779',
+        'CLNDN':'Overgrowth_syndrome_and/or_cerebral_malformations_due_to_abnormalities_in_MTOR_pathway_genes',
+        'CLNDNINCL':'.',
+        'CLNDISDB':'MONDO:MONDO:0100283,MedGen:CN300503',
+        'CLNDISDBINCL':'.',
+        'CLNHGVS':'NC_000001.11:g.11128107G>C',
+        'CLNREVSTAT':'reviewed_by_expert_panel',
+        'CLNSIG':'Pathogenic',
+        'CLNSIGCONF':'.',
+        'CLNSIGINCL':'.',
+        'CLNVC':'single_nucleotide_variant',
+        'CLNVCSO':'SO:0001483',
+        'CLNVI':'.',
+        'DBVARID':'.',
+        'GENEINFO':'MTOR:2475',
+        'MC':'SO:0001583|missense_variant',
+        'ONCDN':'.',
+        'ONCDNINCL':'.',
+        'ONCDISDB':'.',
+        'ONCDISDBINCL':'.',
+        'ONC':'.',
+        'ONCINCL':'.',
+        'ONCREVSTAT':'.',
+        'ONCCONF':'.',
+        'ORIGIN':'1',
+        'RS':'587777893',
+        'SCIDN':'.',
+        'SCIDNINCL':'.',
+        'SCIDISDB':'.',
+        'SCIDISDBINCL':'.',
+        'SCIREVSTAT':'.',
+        'SCI':'.',
+        'SCIINCL':'.',
+        }
+    return row
+
+# Single record, Single mondoID, 1 HPO term, Single gene
+@pytest.fixture
+def test_case2_row():
+    row = {
+        'CHROM':'1',
+        'POS':'964512',
+        'ID':'916564',
+        'REF':'C',
+        'ALT':'A',
+        'QUAL':'.',
+        'FILTER':'.',
+        'AF_ESP':'.',
+        'AF_EXAC':'.',
+        'AF_TGP':'.',
+        'ALLELEID':'904889',
+        'CLNDN':'Tracheoesophageal_fistula',
+        'CLNDNINCL':'.',
+        'CLNDISDB':'Human_Phenotype_Ontology:HP:0002575,MONDO:MONDO:0008586,MeSH:D014138,MedGen:C0040588,OMIM:189960,Orphanet:1199',
+        'CLNDISDBINCL':'.',
+        'CLNHGVS':'NC_000001.11:g.964512C>A',
+        'CLNREVSTAT':'no_assertion_criteria_provided',
+        'CLNSIG':'Likely_pathogenic',
+        'CLNSIGCONF':'.',
+        'CLNSIGINCL':'.',
+        'CLNVC':'single_nucleotide_variant',
+        'CLNVCSO':'SO:0001483',
+        'CLNVI':'.',
+        'DBVARID':'.',
+        'GENEINFO':'KLHL17:339451',
+        'MC':'SO:0001583|missense_variant',
+        'ONCDN':'.',
+        'ONCDNINCL':'.',
+        'ONCDISDB':'.',
+        'ONCDISDBINCL':'.',
+        'ONC':'.',
+        'ONCINCL':'.',
+        'ONCREVSTAT':'.',
+        'ONCCONF':'.',
+        'ORIGIN':'32',
+        'RS':'756054473',
+        'SCIDN':'.',
+        'SCIDNINCL':'.',
+        'SCIDISDB':'.',
+        'SCIDISDBINCL':'.',
+        'SCIREVSTAT':'.',
+        'SCI':'.',
+        'SCIINCL':'.',
+            }
+    return row
+
+# Single record, Single mondoID, 3 HPO terms, Single gene
+@pytest.fixture
+def test_case3_row():
+    row = {
+        'CHROM':'1',
+        'POS':'1233041',
+        'ID':'666963',
+        'REF':'C',
+        'ALT':'T',
+        'QUAL':'.',
+        'FILTER':'.',
+        'AF_ESP':'.',
+        'AF_EXAC':'.',
+        'AF_TGP':'.',
+        'ALLELEID':'654170',
+        'CLNDN':'Spondyloepiphyseal_dysplasia',
+        'CLNDNINCL':'.',
+        'CLNDISDB':'Human_Phenotype_Ontology:HP:0002655,Human_Phenotype_Ontology:HP:0002776,Human_Phenotype_Ontology:HP:0005893,MONDO:MONDO:0016761,MedGen:C0038015,Orphanet:253',
+        'CLNDISDBINCL':'.',
+        'CLNHGVS':'NC_000001.11:g.1233041C>T',
+        'CLNREVSTAT':'criteria_provided,_single_submitter',
+        'CLNSIG':'Likely_pathogenic',
+        'CLNSIGCONF':'.',
+        'CLNSIGINCL':'.',
+        'CLNVC':'single_nucleotide_variant',
+        'CLNVCSO':'SO:0001483',
+        'CLNVI':'.',
+        'DBVARID':'.',
+        'GENEINFO':'B3GALT6:126792',
+        'MC':'SO:0001587|nonsense',
+        'ONCDN':'.',
+        'ONCDNINCL':'.',
+        'ONCDISDB':'.',
+        'ONCDISDBINCL':'.',
+        'ONC':'.',
+        'ONCINCL':'.',
+        'ONCREVSTAT':'.',
+        'ONCCONF':'.',
+        'ORIGIN':'1',
+        'RS':'1239366051',
+        'SCIDN':'.',
+        'SCIDNINCL':'.',
+        'SCIDISDB':'.',
+        'SCIDISDBINCL':'.',
+        'SCIREVSTAT':'.',
+        'SCI':'.',
+        'SCIINCL':'.',
+            }
+    return row
+
+# Multiple records, Multiple mondoID, No HPO, Single gene
+@pytest.fixture
+def test_case4_row():
+    row = {
+    'CHROM':'1',
+    'POS':'11128107',
+    'ID':'156702',
+    'REF':'G',
+    'ALT':'T',
+    'QUAL':'.',
+    'FILTER':'.',
+    'AF_ESP':'.',
+    'AF_EXAC':'.',
+    'AF_TGP':'.',
+    'ALLELEID':'166562',
+    'CLNDN':'not_provided|Overgrowth_syndrome_and/or_cerebral_malformations_due_to_abnormalities_in_MTOR_pathway_genes|Macrocephaly-intellectual_disability-neurodevelopmental_disorder-small_thorax_syndrome',
+    'CLNDNINCL':'.',
+    'CLNDISDB':'MedGen:C3661900|MONDO:MONDO:0100283,MedGen:CN300503|MONDO:MONDO:0014716,MedGen:C4225259,OMIM:616638,Orphanet:457485',
+    'CLNDISDBINCL':'.',
+    'CLNHGVS':'NC_000001.11:g.11128107G>T',
+    'CLNREVSTAT':'reviewed_by_expert_panel',
+    'CLNSIG':'Pathogenic',
+    'CLNSIGCONF':'.',
+    'CLNSIGINCL':'.',
+    'CLNVC':'single_nucleotide_variant',
+    'CLNVCSO':'SO:0001483',
+    'CLNVI':'ClinGen:CA248390',
+    'DBVARID':'.',
+    'GENEINFO':'MTOR:2475',
+    'MC':'SO:0001583|missense_variant',
+    'ONCDN':'.',
+    'ONCDNINCL':'.',
+    'ONCDISDB':'.',
+    'ONCDISDBINCL':'.',
+    'ONC':'.',
+    'ONCINCL':'.',
+    'ONCREVSTAT':'.',
+    'ONCCONF':'.',
+    'ORIGIN':'1',
+    'RS':'587777893',
+    'SCIDN':'.',
+    'SCIDNINCL':'.',
+    'SCIDISDB':'.',
+    'SCIDISDBINCL':'.',
+    'SCIREVSTAT':'.',
+    'SCI':'.',
+    'SCIINCL':'.',
     }
     return row
 
-
+# Multiple records, Multiple mondoID, Multiple HPO, Sigle gene
 @pytest.fixture
-def mondo_and_hpo_row():
+def test_case5_row():
     row = {
-        'CHROM': '1',
-        'POS': '2304067',
-        'ID': '992795',
-        'REF': 'C',
-        'ALT': 'T',
-        'QUAL': '.',
-        'FILTER': '.',
-        'AF_ESP': '8e-05',
-        'AF_EXAC': '2e-05',
-        'AF_TGP': '.',
-        'ALLELEID': '980658',
-        'CLNDN': 'not_provided|Intellectual_disability|Joint_laxity',
-        'CLNDNINCL': '.',
-        'CLNDISDB': 'MedGen:C3661900|Human_Phenotype_Ontology:HP:0000730,Human_Phenotype_Ontology:HP:0001249,Human_Phenotype_Ontology:HP:0001267,Human_Phenotype_Ontology:HP:0001286,Human_Phenotype_Ontology:HP:0002122,Human_Phenotype_Ontology:HP:0002192,Human_Phenotype_Ontology:HP:0002316,Human_Phenotype_Ontology:HP:0002382,Human_Phenotype_Ontology:HP:0002386,Human_Phenotype_Ontology:HP:0002402,Human_Phenotype_Ontology:HP:0002458,Human_Phenotype_Ontology:HP:0002482,Human_Phenotype_Ontology:HP:0002499,Human_Phenotype_Ontology:HP:0002543,Human_Phenotype_Ontology:HP:0003767,Human_Phenotype_Ontology:HP:0006833,Human_Phenotype_Ontology:HP:0007154,Human_Phenotype_Ontology:HP:0007176,Human_Phenotype_Ontology:HP:0007180,MONDO:MONDO:0001071,MeSH:D008607,MedGen:C3714756|Human_Phenotype_Ontology:HP:0001380,Human_Phenotype_Ontology:HP:0001383,Human_Phenotype_Ontology:HP:0001388,Human_Phenotype_Ontology:HP:0002771,MedGen:C0086437',
-        'CLNDISDBINCL': '.',
-        'CLNHGVS': 'NC_000001.11:g.2304067C>T',
-        'CLNREVSTAT': 'criteria_provided,_multiple_submitters,_no_conflicts',
-        'CLNSIG': 'Uncertain_significance',
-        'CLNSIGCONF': '.',
-        'CLNSIGINCL': '.',
-        'CLNVC': 'single_nucleotide_variant',
-        'CLNVCSO': 'SO:0001483',
-        'CLNVI': '.',
-        'DBVARID': '.',
-        'GENEINFO': 'SKI:6497',
-        'MC': 'SO:0001583|missense_variant',
-        'ONCDN': '.',
-        'ONCDNINCL': '.',
-        'ONCDISDB': '.',
-        'ONCDISDBINCL': '.',
-        'ONC': '.',
-        'ONCINCL': '.',
-        'ONCREVSTAT': '.',
-        'ONCCONF': '.',
-        'ORIGIN': '1',
-        'RS': '367916348',
-        'SCIDN': '.',
-        'SCIDNINCL': '.',
-        'SCIDISDB': '.',
-        'SCIDISDBINCL': '.',
-        'SCIREVSTAT': '.',
-        'SCI': '.',
-        'SCIINCL': '.',
+    'CHROM':'2',
+    'POS':'202464950',
+    'ID':'8797',
+    'REF':'C',
+    'ALT':'G',
+    'QUAL':'.',
+    'FILTER':'.',
+    'AF_ESP':'.',
+    'AF_EXAC':'.',
+    'AF_TGP':'.',
+    'ALLELEID':'23836',
+    'CLNDN':'Pulmonary_arterial_hypertension|Pulmonary_hypertension,_primary,_1',
+    'CLNDNINCL':'.',
+    'CLNDISDB':'Human_Phenotype_Ontology:HP:0002092,Human_Phenotype_Ontology:HP:0006546,MONDO:MONDO:0015924,MeSH:D000081029,MedGen:C2973725,Orphanet:182090|MONDO:MONDO:0024533,MedGen:C4552070,OMIM:178600,Orphanet:422',
+    'CLNDISDBINCL':'.',
+    'CLNHGVS':'NC_000002.12:g.202464950C>G',
+    'CLNREVSTAT':'reviewed_by_expert_panel',
+    'CLNSIG':'Pathogenic',
+    'CLNSIGCONF':'.',
+    'CLNSIGINCL':'.',
+    'CLNVC':'single_nucleotide_variant',
+    'CLNVCSO':'SO:0001483',
+    'CLNVI':'ClinGen:CA278072|OMIM:600799.0003',
+    'DBVARID':'.',
+    'GENEINFO':'BMPR2:659',
+    'MC':'SO:0001587|nonsense',
+    'ONCDN':'.',
+    'ONCDNINCL':'.',
+    'ONCDISDB':'.',
+    'ONCDISDBINCL':'.',
+    'ONC':'.',
+    'ONCINCL':'.',
+    'ONCREVSTAT':'.',
+    'ONCCONF':'.',
+    'ORIGIN':'1',
+    'RS':'137852742',
+    'SCIDN':'.',
+    'SCIDNINCL':'.',
+    'SCIDISDB':'.',
+    'SCIDISDBINCL':'.',
+    'SCIREVSTAT':'.',
+    'SCI':'.',
+    'SCIINCL':'.',
     }
     return row
+    #{'MONDO:0015924': ['HP:0002092', 'HP:0006546']}
 
+# Multiple records, Multiple mondoID, Multiple HPO, Multiple gene
+@pytest.fixture
+def test_case6_row():
+    row = {
+    'CHROM':'1',
+    'POS':'216084853',
+    'ID':'179773',
+    'REF':'C',
+    'ALT':'T',
+    'QUAL':'.',
+    'FILTER':'.',
+    'AF_ESP':'.',
+    'AF_EXAC':'6e-05',
+    'AF_TGP':'.',
+    'ALLELEID':'172388',
+    'CLNDN':'not_specified|not_provided|Retinitis_pigmentosa|Retinitis_pigmentosa_39|Usher_syndrome|USH2A-related_disorder|Retinal_dystrophy',
+    'CLNDNINCL':'Retinitis_pigmentosa',
+    'CLNDISDB':'MedGen:CN169374|MedGen:C3661900|Human_Phenotype_Ontology:HP:0000547,MONDO:MONDO:0019200,MeSH:D012174,MedGen:C0035334,OMIM:268000,OMIM:PS268000,Orphanet:791|MONDO:MONDO:0013436,MedGen:C3151138,OMIM:613809,Orphanet:791|MONDO:MONDO:0019501,MeSH:D052245,MedGen:C0271097,OMIM:PS276900,Orphanet:886|MedGen:CN239332|Human_Phenotype_Ontology:HP:0000556,Human_Phenotype_Ontology:HP:0007736,Human_Phenotype_Ontology:HP:0007910,Human_Phenotype_Ontology:HP:0007974,Human_Phenotype_Ontology:HP:0007982,MONDO:MONDO:0019118,MeSH:D058499,MedGen:C0854723,Orphanet:71862',
+    'CLNDISDBINCL':'Human_Phenotype_Ontology:HP:0000547,MONDO:MONDO:0019200,MeSH:D012174,MedGen:C0035334,OMIM:268000,OMIM:PS268000,Orphanet:791',
+    'CLNHGVS':'NC_000001.11:g.216084853C>T',
+    'CLNREVSTAT':'reviewed_by_expert_panel',
+    'CLNSIG':'Pathogenic',
+    'CLNSIGCONF':'.',
+    'CLNSIGINCL':'812445:Likely_pathogenic',
+    'CLNVC':'single_nucleotide_variant',
+    'CLNVCSO':'SO:0001483',
+    'CLNVI':'ClinGen:CA185105',
+    'DBVARID':'.',
+    'GENEINFO':'USH2A:7399|USH2A-AS2:102723833',
+    'MC':'SO:0001583|missense_variant',
+    'ONCDN':'.',
+    'ONCDNINCL':'.',
+    'ONCDISDB':'.',
+    'ONCDISDBINCL':'.',
+    'ONC':'.',
+    'ONCINCL':'.',
+    'ONCREVSTAT':'.',
+    'ONCCONF':'.',
+    'ORIGIN':'1',
+    'RS':'727505116',
+    'SCIDN':'.',
+    'SCIDNINCL':'.',
+    'SCIDISDB':'.',
+    'SCIDISDBINCL':'.',
+    'SCIREVSTAT':'.',
+    'SCI':'.',
+    'SCIINCL':'.',
+    }
+    return row
+    #{'MONDO:0019118': ['HP:0000556', 'HP:0007736', 'HP:0007910', 'HP:0007974', 'HP:0007982']}
+
+
+
+####################################################################
+### Generates koza like output from the input test_case_row data ###
+ 
+@pytest.fixture
+def test_case1_entities(test_case1_row, mock_koza):
+    return mock_koza(INGEST_NAME,
+                     test_case1_row,
+                     TRANSFORM_SCRIPT)
 
 @pytest.fixture
-def no_mondo_entities(no_mondo_row, mock_koza):
-    return mock_koza(
-        INGEST_NAME,
-        no_mondo_row,
-        TRANSFORM_SCRIPT,
-    )
-
+def test_case2_entities(test_case2_row, mock_koza):
+    return mock_koza(INGEST_NAME,
+                     test_case2_row,
+                     TRANSFORM_SCRIPT)
 
 @pytest.fixture
-def mondo_hpo_entities(mondo_and_hpo_row, mock_koza):
-    return mock_koza(
-        INGEST_NAME,
-        mondo_and_hpo_row,
-        TRANSFORM_SCRIPT,
-    )
+def test_case3_entities(test_case3_row, mock_koza):
+    return mock_koza(INGEST_NAME,
+                     test_case3_row,
+                     TRANSFORM_SCRIPT)
+
+@pytest.fixture
+def test_case4_entities(test_case4_row, mock_koza):
+    return mock_koza(INGEST_NAME,
+                     test_case4_row,
+                     TRANSFORM_SCRIPT)
+
+@pytest.fixture
+def test_case5_entities(test_case5_row, mock_koza):
+    return mock_koza(INGEST_NAME,
+                     test_case5_row,
+                     TRANSFORM_SCRIPT)
+
+@pytest.fixture
+def test_case6_entities(test_case6_row, mock_koza):
+    return mock_koza(INGEST_NAME,
+                     test_case6_row,
+                     TRANSFORM_SCRIPT)
 
 
-# Test the output of the transform
-def test_no_mondo_row(no_mondo_entities):
-    assert len(no_mondo_entities) == 0
+
+########################
+### Our actual tests ###
+
+def test_case1(test_case1_entities):
+    assert len(test_case1_entities) == 3 # SequenceVariant, VariantToDisease, VariantToGene
+
+def test_case2(test_case2_entities):
+    assert len(test_case2_entities) == 4 # SequenceVariant, VariantToDisease, VariantToGene, VariantToPhenotype
+
+def test_case3(test_case3_entities):
+    assert len(test_case3_entities) == 6 # SequenceVariant, VariantToDisease, VariantToGene, VariantToPhenotype, VariantToPhenotype, VariantToPhenotype
+    assert len([association for association in test_case3_entities if isinstance(association, VariantToPhenotypicFeatureAssociation)]) == 2
+
+def test_case4(test_case4_entities):
+    assert len(test_case4_entities) == 3 # SequenceVariant, VariantToDisease, VariantToGene
+    assert test_case4_entities[2].object == "MONDO:0100283" # Multiple mondoids are available and this is the one that should be chosen
+
+def test_case5(test_case5_entities):
+    assert len(test_case5_entities) == 5 # SequenceVariant, VariantToDisease, VariantToGene, VariantToPhenotype1, VariantToPhenotype2
+    assert test_case5_entities[2].object == "MONDO:0015924" # Multiple mondoids are available and this is the one that should be chosen
+    assert len([association for association in test_case5_entities if isinstance(association, VariantToPhenotypicFeatureAssociation)]) == 2
+
+def test_case6(test_case6_entities):
+    assert len(test_case6_entities) == 9 # SequenceVariant, VariantToDisease, VariantToGene1, VariantToGene2, VariantToPhenotype_x_5 
+    assert test_case6_entities[2].object == "MONDO:0019118" # Multiple mondoids are available and this is the one that should be chosen
+    assert len([association for association in test_case6_entities if isinstance(association, VariantToGeneAssociation)]) == 2
+    assert len([association for association in test_case6_entities if isinstance(association, VariantToPhenotypicFeatureAssociation)]) == 5
 
 
-def test_mondo_hpo_entities_hpo(mondo_hpo_entities):
-    assert (
-        len(
-            [
-                association
-                for association in mondo_hpo_entities
-                if isinstance(association, VariantToPhenotypicFeatureAssociation)
-            ]
-        )
-        == 23
-    )
-
-
-def test_single_gene(mondo_hpo_entities):
-    assert (
-        len([association for association in mondo_hpo_entities if isinstance(association, VariantToGeneAssociation)])
-        == 1
-    )
+# TO DO: Tests for proper predicates? Test rows for variants that are not of review status 3 stars or above? 
+# (Tricky because paramters / decisions about what information actually gets pulled and when can alter the results obtained for variants with a review status of less than 3 stars


### PR DESCRIPTION
- Added code to pull in clinvar submission_summary file to determine which submission records of each vcf variant should be included in the graph. 
- Added code to pull in medgen id mappings, and the mondo_sssom file to map any given disease id back to a mondo id
- Created a framework to create variants and edges based on review stars. This can be altered in the future to include more variants and edges by updating the review star minimum and manual mapping each unique clinical significance term reported to the desired predicate