### PR TITLE
Bump actions/checkout from v4 to v5

### DIFF
--- a/.copier-answers.yml
+++ b/.copier-answers.yml
@@ -1,4 +1,4 @@
-_commit: b7f2804
+_commit: 1e35b56
 _src_path: gh:monarch-initiative/koza-ingest-template
 copyright_year: '2026'
 email: info@monarchinitiative.org

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -14,7 +14,7 @@ jobs:
         python-version: ["3.10", "3.11", "3.12"]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
       - name: Install uv
         uses: astral-sh/setup-uv@v4


### PR DESCRIPTION
## Summary
- `copier update` to pick up checkout v4 → v5 from koza-ingest-template (PR #24 there).

## Test plan
- [ ] CI passes